### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
 jobs:
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/yop-platform/yeepay-mcp/security/code-scanning/1](https://github.com/yop-platform/yeepay-mcp/security/code-scanning/1)

To fix the issue, explicitly add the `permissions` block to the workflow file. This block will define the least privilege necessary for the job. In this case:
- The `contents` permission is set to `read` to allow interactions such as checking out code.
- The `issues` and `pull-requests` permissions are set to `write` to accommodate the publishing and release process.

The `permissions` block will be added at the root level of the workflow file to apply to all jobs within this workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow permissions for automated release processes to improve security and access control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->