### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 The Yeepay MCP service provides integration with Yeepay services via the Model Context Protocol (MCP).
 
+<a href="https://glama.ai/mcp/servers/@yop-platform/yeepay-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@yop-platform/yeepay-mcp/badge" alt="yeepay-mcp MCP server" />
+</a>
+
 [![npm version](https://img.shields.io/npm/v/@yeepay/yeepay-mcp.svg)](https://www.npmjs.com/package/@yeepay/yeepay-mcp)
 [![npm downloads](https://img.shields.io/npm/dm/@yeepay/yeepay-mcp.svg)](https://www.npmjs.com/package/@yeepay/yeepay-mcp)
 


### PR DESCRIPTION
This PR adds a badge for the [yeepay-mcp](https://glama.ai/mcp/servers/@yop-platform/yeepay-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@yop-platform/yeepay-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@yop-platform/yeepay-mcp/badge" alt="yeepay-mcp MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an image badge with a link to the Yeepay MCP server on glama.ai at the top of the README.
  * Minor whitespace adjustment at the end of the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->